### PR TITLE
feat(ui): Add reusable UI components (Button, Input, Card)

### DIFF
--- a/src/pages/ComponentsTestPage.tsx
+++ b/src/pages/ComponentsTestPage.tsx
@@ -111,7 +111,7 @@ const ComponentsTestPage = () => {
             <div>
               <h2 className="text-2xl font-semibold mb-4">Cards</h2>
 
-              <div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* Different paddings */}
                 <Card padding="sm" shadow="sm">
                   <h3 className="font-semibold">Small Padding</h3>
@@ -131,6 +131,49 @@ const ComponentsTestPage = () => {
                 </Card>
               </div>
             </div>
+
+            {/* Form Example */}
+            <Card>
+              <h2 className="text-2xl font-semibold mb-4">
+                Ejemplo de formulario
+              </h2>
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <Input
+                  label="Email"
+                  type="email"
+                  placeholder="tu@mail.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  required
+                />
+
+                <Input
+                  label="Password"
+                  type="password"
+                  placeholder="••••••••"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+
+                <div className="flex gap-2">
+                  <Button type="submit" isLoading={isLoading}>
+                    Enviar
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => {
+                      setEmail("");
+                      setPassword("");
+                      setEmailError("");
+                    }}
+                  >
+                    Limpiar
+                  </Button>
+                </div>
+              </form>
+            </Card>
           </div>
         </Card>
       </div>


### PR DESCRIPTION
### PR DESCRIPTION
## Summary 
Add reusable UI components (Button, Input, Card) with Tailwind Css to establish a consistent desing system. 

## Changes 
### Button Components 
- [x] Variants: primary, secondary, danger, ghost 
- [x] Sizes: sm, md, lg
- [x] States: normal, disabled, loading 
- [ ] Functional spinner 
- [x] Full width option 
- [x] forwardRef support

### Input Component 
- [x] Label with automatic ID generation
- [x] Error state with red border and message 
- [x Helper text
- [x] Disabled state
- [x] forwardRef support for form integration 

### Card component
- [x] Padding options: none, sm, md, lg
- [x] Shasow options: none, sm, md, lg
- [x] Flexible content composition 

### Other 
- [x] Central export from @/components/ui 
- [x] Test Page to verify all components 
- [x] Typescript interfaces for all props

### Screenshots
<img width="1896" height="1030" alt="image" src="https://github.com/user-attachments/assets/54d0df8f-73f1-49cd-8c9e-6b8948ebcb96" />

<img width="1896" height="1030" alt="image" src="https://github.com/user-attachments/assets/37305e25-0e94-4542-b8cb-508f9b59599d" />

<img width="1896" height="1030" alt="image" src="https://github.com/user-attachments/assets/bbd283c7-2bba-4bef-a118-496b7725d752" />

<img width="691" height="235" alt="image" src="https://github.com/user-attachments/assets/77f9f4eb-0115-4789-9fff-19716042f1cd" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/305877dc-9b61-4ba2-b814-bb015c85a376" />

<img width="1896" height="1030" alt="image" src="https://github.com/user-attachments/assets/0c599eea-2662-4e4c-9f3f-7be66cb2e6aa" />

<img width="1608" height="944" alt="image" src="https://github.com/user-attachments/assets/f36aaf7c-3f68-475f-8dcb-ee7db9721889" />

## Related Issues 

- Spinner in button have a bug in circle.


